### PR TITLE
Fix links for move to "brimsec" org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Sample Data
 
-To help you get started quickly with [`zq`](https://github.com/mccanne/zq), this repository contains small sample sets of [Zeek](https://www.zeek.org/) data. There are four different log formats available, all representing events based on the same network traffic:
+To help you get started quickly with [`zq`](https://github.com/brimsec/zq), this repository contains small sample sets of [Zeek](https://www.zeek.org/) data. There are four different log formats available, all representing events based on the same network traffic:
 
 | Directory | Format |
 |-----------|--------|
 | [zeek-default/](zeek-default) | [Zeek default output format](https://docs.zeek.org/en/stable/examples/logs/) |
 | [zeek-ndjson/](zeek-ndjson) | [ Newline-delimited JSON (NDJSON)](http://ndjson.org/), as output by the Zeek package for [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs) |
-| [zng/](zng) | [ZNG](https://github.com/mccanne/zq/blob/master/pkg/zng/docs/README.md), the default output format of [`zq`](https://github.com/mccanne/zq) |
-| [bzng/](bzng) | [BZNG](https://github.com/mccanne/zq/blob/master/pkg/zng/docs/README.md), the binary output format of [`zq`](https://github.com/mccanne/zq) |
+| [zng/](zng) | [ZNG](https://github.com/brimsec/zq/blob/master/pkg/zng/docs/README.md), the default output format of [`zq`](https://github.com/brimsec/zq) |
+| [bzng/](bzng) | [BZNG](https://github.com/brimsec/zq/blob/master/pkg/zng/docs/README.md), the binary output format of [`zq`](https://github.com/brimsec/zq) |
 
-The examples in the [`zq`](https://github.com/mccanne/zq) documentation are based on this sample data.
+The examples in the [`zq`](https://github.com/brimsec/zq) documentation are based on this sample data.
 
 # Origin/License
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ To help you get started quickly with [`zq`](https://github.com/brimsec/zq), this
 |-----------|--------|
 | [zeek-default/](zeek-default) | [Zeek default output format](https://docs.zeek.org/en/stable/examples/logs/) |
 | [zeek-ndjson/](zeek-ndjson) | [ Newline-delimited JSON (NDJSON)](http://ndjson.org/), as output by the Zeek package for [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs) |
-| [zng/](zng) | [ZNG](https://github.com/brimsec/zq/blob/master/pkg/zng/docs/README.md), the default output format of [`zq`](https://github.com/brimsec/zq) |
-| [bzng/](bzng) | [BZNG](https://github.com/brimsec/zq/blob/master/pkg/zng/docs/README.md), the binary output format of [`zq`](https://github.com/brimsec/zq) |
+| [zng/](zng) | [ZNG](https://github.com/brimsec/zq/blob/master/zng/docs/README.md), the default output format of [`zq`](https://github.com/brimsec/zq) |
+| [bzng/](bzng) | [BZNG](https://github.com/brimsec/zq/blob/master/zng/docs/README.md), the binary output format of [`zq`](https://github.com/brimsec/zq) |
 
 The examples in the [`zq`](https://github.com/brimsec/zq) documentation are based on this sample data.
 


### PR DESCRIPTION
A couple of the links were even pre-broken due to other moves on the `zq` side.