### PR TITLE
Change wrccdc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Because prior changes to the ZNG/ZSON/TZNG output formats have added some bulk t
 
 # Origin/License
 
-This sample data set was generated from a subset of the [packet capture archives](https://archive.wrccdc.org/pcaps/) that are distributed by the [WRCCDC](https://www.wrccdc.org/).
+This sample data set was generated from a subset of the packet capture archives (formerly at https://archive.wrccdc.org/pcaps, though the site has been down of late) that are distributed by the [WRCCDC](https://www.wrccdc.org/).
 
 This sample data is [licensed](LICENSE) under a Creative Commons Attribution-ShareAlike 4.0 International License, as it is built upon the WRCCDC PCAP data that is distributed under the same license.
 
@@ -33,7 +33,7 @@ We would like to express our thanks to the WRCCDC for generously making their pa
 
 # Creation
 
-The data set was made from the several PCAP files in the [2018](https://archive.wrccdc.org/pcaps/2018/) set. [Zeek v3.0.0](https://github.com/zeek/zeek/releases/tag/v3.0.0) was used in its default configuration with the only change being the addition/enabling of the [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs) package. The packet captures were then processed via the command-line:
+The data set was made from the several PCAP files in the 2018 set. [Zeek v3.0.0](https://github.com/zeek/zeek/releases/tag/v3.0.0) was used in its default configuration with the only change being the addition/enabling of the [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs) package. The packet captures were then processed via the command-line:
 
 ```
 # zeek -r wrccdc.2018-03-24.101533000000000.pcap -r wrccdc.2018-03-24.101551000000000.pcap -r wrccdc.2018-03-24.101610000000000.pcap -r wrccdc.2018-03-24.101629000000000.pcap -r wrccdc.2018-03-24.101737000000000.pcap -r wrccdc.2018-03-24.101939000000000.pcap -r wrccdc.2018-03-24.102051000000000.pcap -r wrccdc.2018-03-24.102126000000000.pcap -r wrccdc.2018-03-24.102233000000000.pcap -r wrccdc.2018-03-24.102443000000000.pcap -r wrccdc.2018-03-24.102602000000000.pcap -r wrccdc.2018-03-24.102643000000000.pcap -r wrccdc.2018-03-24.102717000000000.pcap -r wrccdc.2018-03-24.102733000000000.pcap -r wrccdc.2018-03-24.102747000000000.pcap -r wrccdc.2018-03-24.102831000000000.pcap -r wrccdc.2018-03-24.102920000000000.pcap -r wrccdc.2018-03-24.103009000000000.pcap -r wrccdc.2018-03-24.103049000000000.pcap -r wrccdc.2018-03-24.103117000000000.pcap -r wrccdc.2018-03-24.103152000000000.pcap -r wrccdc.2018-03-24.103210000000000.pcap -r wrccdc.2018-03-24.103224000000000.pcap -r wrccdc.2018-03-24.103256000000000.pcap -r wrccdc.2018-03-24.103420000000000.pcap -r wrccdc.2018-03-24.103630000000000.pcap local


### PR DESCRIPTION
The site for the pcap archive at [https://archive.wrccdc.org](https://archive.wrccdc.org/) has been unreachable for several days, which sets off failures in the nightly markdown link checker. I've emailed two different wrccdc email addresses to ask if the outage is temporary but neither has responded, so I feel like I can't responsibly link to them like we once did.

Unlike in the companion PRs brimdata/zed#2622 and brimdata/brim#1586, here I'm being explicit about its non-reachability, since this is one place where we advise users that they could download these files themselves, and for now they can't.